### PR TITLE
procps is needed by omada server to detect mongod startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /omada
 COPY entrypoint.sh .
 ENTRYPOINT /omada/entrypoint.sh
 RUN set -x && apt-get update -y > /dev/null && \
-    apt-get install -y libcap-dev wget net-tools > /dev/null && \
+    apt-get install -y libcap-dev wget net-tools procps > /dev/null && \
     RELEASE_YEAR=`echo "${RELEASE_DATE}" | cut -c1-4` && \
     RELEASE_YEARMONTH=`echo "${RELEASE_DATE}" | cut -c1-6` && \
     wget -q "https://static.tp-link.com/${RELEASE_YEAR}/${RELEASE_YEARMONTH}/${RELEASE_DATE}/Omada_Controller_v${OMADA_VERSION}_linux_x64.tar.gz" -O omada.tar.gz && \


### PR DESCRIPTION
Sorry, my bad: I was wrong (I added procps to debug, but it happened to get rid of the error that I added it to help debug, sort of a Heisen-change).  procps really is needed.  Here's the startup error without it (though the omada server sort of works, it looks like it has a thread that keeps restarting mongod and fills up logs).  The log complaints go away and omada seems happy with procps.

2020-09-15 02:51:58 [Thread-3] [INFO]-[SourceFile:139] - mongodb process id is :229
2020-09-15 02:51:58 [Thread-3] [INFO]-[SourceFile:120] - Mongo DB server started
2020-09-15 02:52:08 [Thread-3] [WARN]-[SourceFile:173] - Cannot run program "ps": error=2, No such file or directory
java.io.IOException: Cannot run program "ps": error=2, No such file or directory
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048) ~[?:1.8.0_162]
        at java.lang.Runtime.exec(Runtime.java:620) ~[?:1.8.0_162]
        at java.lang.Runtime.exec(Runtime.java:450) ~[?:1.8.0_162]
        at java.lang.Runtime.exec(Runtime.java:347) ~[?:1.8.0_162]
        at com.tp_link.eap.util.m.a.c(SourceFile:175) ~[eap-infrastructure-3.2.10.jar:?]
        at com.tp_link.eap.util.m.a.a(SourceFile:119) ~[eap-infrastructure-3.2.10.jar:?]
        at com.tp_link.eap.start.c.c.g(SourceFile:152) [eap-start-3.2.10.jar:?]
        at com.tp_link.eap.start.a.t(SourceFile:308) [eap-start-3.2.10.jar:?]
        at com.tp_link.eap.start.a.b(SourceFile:40) [eap-start-3.2.10.jar:?]
        at com.tp_link.eap.start.b.run(SourceFile:489) [eap-start-3.2.10.jar:?]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_162]
Caused by: java.io.IOException: error=2, No such file or directory
        at java.lang.UNIXProcess.forkAndExec(Native Method) ~[?:1.8.0_162]
        at java.lang.UNIXProcess.<init>(UNIXProcess.java:247) ~[?:1.8.0_162]
        at java.lang.ProcessImpl.start(ProcessImpl.java:134) ~[?:1.8.0_162]
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029) ~[?:1.8.0_162]
        ... 10 more
2020-09-15 02:52:08 [Thread-3] [INFO]-[SourceFile:176] - mongod is not running
2020-09-15 02:52:08 [Thread-3] [INFO]-[SourceFile:491] - mongod was shutdown , restarting it
2020-09-15 02:52:08 [Thread-3] [INFO]-[SourceFile:190] - Going to stop mongod which pid is 229
2020-09-15 02:52:08 [Thread-3] [WARN]-[SourceFile:213] - shutdown failed .
java.io.IOException: Cannot run program "kill": error=2, No such file or directory
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048) ~[?:1.8.0_162]
        at java.lang.Runtime.exec(Runtime.java:620) ~[?:1.8.0_162]
        at java.lang.Runtime.exec(Runtime.java:450) ~[?:1.8.0_162]
        at java.lang.Runtime.exec(Runtime.java:347) ~[?:1.8.0_162]
        at com.tp_link.eap.util.m.a.c(SourceFile:175) ~[eap-infrastructure-3.2.10.jar:?]
        at com.tp_link.eap.util.m.a.a(SourceFile:203) ~[eap-infrastructure-3.2.10.jar:?]
        at com.tp_link.eap.start.c.c.b(SourceFile:191) [eap-start-3.2.10.jar:?]
        at com.tp_link.eap.start.c.a.f(SourceFile:89) [eap-start-3.2.10.jar:?]
        at com.tp_link.eap.start.a.w(SourceFile:330) [eap-start-3.2.10.jar:?]
        at com.tp_link.eap.start.a.v(SourceFile:316) [eap-start-3.2.10.jar:?]
        at com.tp_link.eap.start.a.c(SourceFile:40) [eap-start-3.2.10.jar:?]
        at com.tp_link.eap.start.b.run(SourceFile:492) [eap-start-3.2.10.jar:?]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_162]
Caused by: java.io.IOException: error=2, No such file or directory
        at java.lang.UNIXProcess.forkAndExec(Native Method) ~[?:1.8.0_162]
        at java.lang.UNIXProcess.<init>(UNIXProcess.java:247) ~[?:1.8.0_162]
        at java.lang.ProcessImpl.start(ProcessImpl.java:134) ~[?:1.8.0_162]
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029) ~[?:1.8.0_162]
        ... 12 more
2020-09-15 02:52:08 [Thread-3] [INFO]-[SourceFile:139] - mongodb process id is :250

